### PR TITLE
Read Vernal Pool Successfully

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ xlsform -m digest -w examples/example_survey.xlsx -f examples/digested_example_j
 ```bash
 pytest
 ```
+
+## Some Odd Notes
+1. I've found that sometimes you have to save a form locally before the xlsform tool can digest it. I suppose there's some kind of type mismatch that excel resolves upon the first save.

--- a/xlsform/helpers.py
+++ b/xlsform/helpers.py
@@ -151,7 +151,10 @@ def read_settings(sheet):
         key = column[0].value.strip()
         if not key:
             continue
-        settings[key] = next(e.value.strip() for e in column[1:] if e.value and e.value.strip())
+        try:
+            settings[key] = next(e.value.strip() for e in column[1:] if e.value and e.value.strip())
+        except StopIteration:
+            pass
     return settings
 
 class SettingsHelper(SheetHelper):

--- a/xlsform/tests/test_settings.py
+++ b/xlsform/tests/test_settings.py
@@ -72,3 +72,18 @@ class TestReadSettings(unittest.TestCase):
             'style': 'grid'
         }
         assert settings == expected_settings
+
+    def test_empty_setting(self):
+        workbook = Workbook()
+        sheet = workbook.active
+        # setup columns
+        sheet.cell(row=1, column=1, value='title')
+        sheet.cell(row=1, column=3, value='style')
+        # data
+        sheet.cell(row=2, column=1, value='A Survey')
+
+        settings = read_settings(sheet)
+        expected_settings = {
+            'title': 'A Survey'
+        }
+        assert settings == expected_settings


### PR DESCRIPTION
Had to save the XLSForm locally and allow for empty settings.

Resolves https://github.com/earthwiseaware/xlsform/issues/2